### PR TITLE
allow access to unprotected subojebcts for PersistentResourceDirectory

### DIFF
--- a/plone/resource/directory.py
+++ b/plone/resource/directory.py
@@ -28,6 +28,8 @@ class PersistentResourceDirectory(object):
     and that files are instances of OFS.Image.File.
     """
     implements(IWritableResourceDirectory)
+    
+    __allow_access_to_unprotected_subobjects__ = True
 
     def __init__(self, context=None):
         if context is None:


### PR DESCRIPTION
PersistentResourceDirectory the class has no security assertions, therefore it was not possible to use restrictedTraverse to access theme content.
this patch sets **allow_access_to_unprotected_subobjects** to True on  PersistentResourceDirectory (as with FileSystemResourceDirectory)
