### PR TITLE
Do not leave an .svn file behind when running the tests.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ New:
 
 Fixes:
 
+- Do not leave an ``.svn`` file behind when running the tests.  [maurits]
+
 - Use zope.interface decorator.
   [gforcada]
 

--- a/plone/resource/tests/test_directory.py
+++ b/plone/resource/tests/test_directory.py
@@ -225,7 +225,7 @@ class TestFilesystemResourceDirectory(unittest.TestCase):
     def test_contains(self):
         dir = self._makeOne()
         self.assertTrue('demo' in dir)
-        
+
     def test_openFile(self):
         dir = self._makeOne()
         file = dir.openFile('demo/foo/test.html')
@@ -245,10 +245,13 @@ class TestFilesystemResourceDirectory(unittest.TestCase):
 
     def test_listDirectory_filters_by_name(self):
         dir = self._makeOne()
-        name = '.svn'
-        if name not in os.listdir(dir.directory): # pragma: no cover
-            f = open(os.path.join(dir.directory, name), 'w')
+        name = '.dummy'
+        file_path = os.path.join(dir.directory, name)
+        if name not in os.listdir(dir.directory):
+            f = open(file_path, 'w')
             f.write("")
             f.close()
         self.assertTrue(name in os.listdir(dir.directory))
         self.assertEqual(['demo'], dir.listDirectory())
+        # Cleanup created file.
+        os.remove(file_path)


### PR DESCRIPTION
Do create a file, but call it `.dummy` for good measure, and remove it afterwards.

The `.svn` was presumably from the days when plone.resource was still in subversion, which for older versions of subversion meant that there was a `.svn` directory already there, and should definitely not be removed.