### PR TITLE
Use mimetypes_registry utility to determine mimetype if available.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Use ``mimetypes_registry`` utility to dertermine mimetype if available.
+  [jensens]
 
 Bug fixes:
 


### PR DESCRIPTION
We register many more mimetypes in MTR than Pythons build in ``mimetypes`` module offers. If it comes to font-files this makes a difference.