### PR TITLE
Fixed ValueError in FilesystemResourceDirectory repr [master]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,12 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fixed 'ValueError: substring not found' in ``FilesystemResourceDirectory`` representation.
+  This happens when you register a directory with a name that differs from the directory name.
+  Visiting the ``/++theme++myname`` url would then give this error.
+  We also avoid listing a longer part of the path in case the directory name happens to be in the path multiple times.
+  [maurits]
+
 
 1.2.1 (2016-12-30)
 ------------------

--- a/plone/resource/directory.py
+++ b/plone/resource/directory.py
@@ -215,8 +215,7 @@ class FilesystemResourceDirectory(object):
         self._parent = value
 
     def __repr__(self):
-        subpath = self.directory[self.directory.index(self.__name__):]
-        return '<%s object at %s>' % (self.__class__.__name__, subpath)
+        return '<%s object at %s>' % (self.__class__.__name__, self.__name__)
 
     def _resolveSubpath(self, path):
         parts = path.split('/')

--- a/plone/resource/tests/test_directory.py
+++ b/plone/resource/tests/test_directory.py
@@ -214,27 +214,32 @@ class TestPersistentResourceDirectory(unittest.TestCase):
         dir.writeFile('test', 'my test is modified')
         self.assertTrue(isinstance(events[0], PloneResourceCreatedEvent))
         self.assertEqual(
-            str(events[0].object), 
+            str(events[0].object),
             'my test'
         )
         self.assertTrue(isinstance(events[1], PloneResourceModifiedEvent))
         self.assertEqual(
-            str(events[1].object), 
+            str(events[1].object),
             'my test is modified'
         )
 
 
 class TestFilesystemResourceDirectory(unittest.TestCase):
 
-    def _makeOne(self):
+    def _makeOne(self, name=None):
         from plone.resource.directory import FilesystemResourceDirectory
         path = os.path.join(os.path.dirname(__file__), 'resources')
-        return FilesystemResourceDirectory(path)
+        return FilesystemResourceDirectory(path, name=name)
 
     def test_repr(self):
         dir = self._makeOne()
-        subpath = dir.directory[dir.directory.index(dir.__name__):]
-        s = '<FilesystemResourceDirectory object at %s>' % subpath
+        s = '<FilesystemResourceDirectory object at resources>'
+        self.assertEqual(s, repr(dir))
+
+    def test_repr(self):
+        dir = self._makeOne(name='something-else')
+        s = '<FilesystemResourceDirectory object at something-else>'
+        # This used to give a ValueError: substring not found
         self.assertEqual(s, repr(dir))
 
     def test_publishTraverse_directory(self):


### PR DESCRIPTION
This is the forward port (cherry-pick) of PR #20 for master.

Fixed 'ValueError: substring not found' in `FilesystemResourceDirectory` representation.

This happens when you register a directory with a name that differs from the directory name.
Visiting the ``/++theme++myname`` url would then give this error.

We also avoid listing a longer part of the path in case the directory name happens to be in the path multiple times.
Case in point: if you would register the `template` dir of `plone.app.theming` as a plone static dir with name `theming`, and visit the `++theme++theming` url,
you would see something like this:

    <FilesystemResourceDirectory object at theming-1.1.8-py2.7.egg/plone/app/theming/themes/template>

That is just silly.
We simply show the name now:

    <FilesystemResourceDirectory object at theming>

If the name and the directory would have matched, which is the default when you do not give a name, then that would be what is shown anyway.